### PR TITLE
Remove global variables and use PrecompileTools

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,8 +3,8 @@ uuid = "958354d5-50ac-4b0d-a93a-da730912cc6c"
 
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
-GAMS = "1ca51c6a-1b4d-4546-9ae1-53e0a243ab12"
 HiGHS = "87dc4568-4c63-4d18-b0c0-bb2238e4078b"
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
+PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 SQLite = "0aa819cd-b072-5ff4-a722-6bc24af294d9"

--- a/demo.jl
+++ b/demo.jl
@@ -1,16 +1,8 @@
-using JuMP;
-using HiGHS;
-using TIMES;
-#using GAMS;
+using JuMP
+using HiGHS
+using TIMES
 
 @time "Create demo" demo = TIMES.create_model("PROTO.db3")
-
-# Set solver
 set_optimizer(demo, HiGHS.Optimizer)
-#set_optimizer(model, GAMS.Optimizer)
-#set_optimizer_attribute(model, GAMS.Solver(), "CPLEX")
-
 @time "Solve model" optimize!(demo)
-
-# Print solution summary
 solution_summary(demo)

--- a/src/TIMES.jl
+++ b/src/TIMES.jl
@@ -2,47 +2,47 @@ module TIMES
 
 export create_model
 
-using JuMP
-using DataFrames
-using SQLite
-
-function __init__()
-    # Nothing yet!
-end
+import DataFrames
+import JuMP
+import PrecompileTools
+import SQLite
 
 # Define TIMES sets
-include("./sets.jl")
+include("sets.jl")
 # Functions to read data from database
-include("./load_data.jl")
+include("load_data.jl")
 # Compute additional sets
-include("./compute_sets.jl")
+include("compute_sets.jl")
 # Compute additional parameters
-include("./parameters.jl")
+include("parameters.jl")
 # Compute indexes for equations and variables
-include("./compute_indexes.jl")
+include("compute_indexes.jl")
 # Create Variables
-include("./variables.jl")
+include("variables.jl")
 # Define objective Function
-include("./objective.jl")
+include("objective.jl")
 # Generate constraints
-include("./constraints.jl")
-
+include("constraints.jl")
 
 function create_model(file_path)
-
-    model = Model()
-
-    data = read_data(file_path)
-    create_read_symbols(data)
-    create_parameters()
-    compute_sets(data)
-    indices = compute_indexes(data)
-    create_variables(model, indices)
-    create_objective(model)
-    create_constraints(model, indices)
-
+    # Read data
+    df_data = read_data(file_path)
+    sets = compute_sets(df_data)
+    indices = compute_indexes(df_data)
+    data = create_read_symbols(df_data)
+    # Setup JuMP model
+    model = JuMP.Model()
+    create_parameters!(model, data)
+    create_variables!(model, indices, data)
+    create_objective!(model, data)
+    create_constraints!(model, indices, data, sets)
     return model
+end
 
+PrecompileTools.@setup_workload begin
+    PrecompileTools.@compile_workload begin
+        create_model("PROTO.db3")
+    end
 end
 
 end

--- a/src/compute_indexes.jl
+++ b/src/compute_indexes.jl
@@ -2,29 +2,29 @@
 
 function compute_indexes(data)
     # Create intermediate dataframes
-    EQs_CAPACT = innerjoin(
-        rename(data["RTP_VINTYR"], [:r, :v, :t, :p]),
-        rename(data["AFS"], [:r, :t, :p, :s, :bd]),
+    EQs_CAPACT = DataFrames.innerjoin(
+        DataFrames.rename(data["RTP_VINTYR"], [:r, :v, :t, :p]),
+        DataFrames.rename(data["AFS"], [:r, :t, :p, :s, :bd]),
         on = [:r, :t, :p],
     )
 
-    EQs_FLOSHR = innerjoin(
-        innerjoin(
-            rename(data["FLO_SHAR"][:, Not(:value)], [:r, :v, :p, :c, :cg, :s, :bd]),
-            rename(data["RTP_VARA"], [:r, :t, :p]),
+    EQs_FLOSHR = DataFrames.innerjoin(
+        DataFrames.innerjoin(
+            DataFrames.rename(data["FLO_SHAR"][:, DataFrames.Not(:value)], [:r, :v, :p, :c, :cg, :s, :bd]),
+            DataFrames.rename(data["RTP_VARA"], [:r, :t, :p]),
             on = [:r, :p],
         ),
-        innerjoin(
-            rename(data["RTP_VINTYR"], [:r, :v, :t, :p]),
-            rename(data["RPCS_VAR"], [:r, :p, :c, :s]),
+        DataFrames.innerjoin(
+            DataFrames.rename(data["RTP_VINTYR"], [:r, :v, :t, :p]),
+            DataFrames.rename(data["RPCS_VAR"], [:r, :p, :c, :s]),
             on = [:r, :p],
         ),
         on = [:r, :v, :p, :c, :s, :t],
     )
 
-    vars_base = innerjoin(
-        rename(data["RTP_VINTYR"], [:r, :v, :t, :p]),
-        rename(data["RTP_VARA"], [:r, :t, :p]),
+    vars_base = DataFrames.innerjoin(
+        DataFrames.rename(data["RTP_VINTYR"], [:r, :v, :t, :p]),
+        DataFrames.rename(data["RTP_VARA"], [:r, :t, :p]),
         on = [:r, :t, :p],
     )
 
@@ -35,13 +35,13 @@ function compute_indexes(data)
     indices["EQ_ACTFLO"] = Set(
         Tuple.(
             eachrow(
-                innerjoin(
-                    innerjoin(
-                        rename(data["RTP_VINTYR"], [:r, :v, :t, :p]),
-                        rename(data["PRC_TS"], [:r, :p, :s]),
+                DataFrames.innerjoin(
+                    DataFrames.innerjoin(
+                        DataFrames.rename(data["RTP_VINTYR"], [:r, :v, :t, :p]),
+                        DataFrames.rename(data["PRC_TS"], [:r, :p, :s]),
                         on = [:r, :p],
                     ),
-                    rename(data["PRC_ACT"], [:r, :p]),
+                    DataFrames.rename(data["PRC_ACT"], [:r, :p]),
                     on = [:r, :p],
                 ),
             )
@@ -66,15 +66,15 @@ function compute_indexes(data)
     indices["EQE_ACTEFF"] = Set(
         Tuple.(
             eachrow(
-                innerjoin(
-                    innerjoin(
-                        rename(data["RPG_ACE"], [:r, :p, :cg, :io]),
-                        rename(data["RTP_VARA"], [:r, :t, :p]),
+                DataFrames.innerjoin(
+                    DataFrames.innerjoin(
+                        DataFrames.rename(data["RPG_ACE"], [:r, :p, :cg, :io]),
+                        DataFrames.rename(data["RTP_VARA"], [:r, :t, :p]),
                         on = [:r, :p],
                     ),
-                    innerjoin(
-                        rename(data["RTP_VINTYR"], [:r, :v, :t, :p]),
-                        rename(data["RPS_S1"], [:r, :p, :s]),
+                    DataFrames.innerjoin(
+                        DataFrames.rename(data["RTP_VINTYR"], [:r, :v, :t, :p]),
+                        DataFrames.rename(data["RPS_S1"], [:r, :p, :s]),
                         on = [:r, :p],
                     ),
                     on = [:r, :p, :t],
@@ -86,21 +86,21 @@ function compute_indexes(data)
     indices["EQ_PTRANS"] = Set(
         Tuple.(
             eachrow(
-                innerjoin(
-                    innerjoin(
-                        innerjoin(
-                            rename(data["RP_PTRAN"], [:r, :p, :cg1, :cg2, :s1]),
-                            rename(data["RTP_VARA"], [:r, :t, :p]),
+                DataFrames.innerjoin(
+                    DataFrames.innerjoin(
+                        DataFrames.innerjoin(
+                            DataFrames.rename(data["RP_PTRAN"], [:r, :p, :cg1, :cg2, :s1]),
+                            DataFrames.rename(data["RTP_VARA"], [:r, :t, :p]),
                             on = [:r, :p],
                         ),
-                        innerjoin(
-                            rename(data["RTP_VINTYR"], [:r, :v, :t, :p]),
-                            rename(data["RPS_S1"], [:r, :p, :s]),
+                        DataFrames.innerjoin(
+                            DataFrames.rename(data["RTP_VINTYR"], [:r, :v, :t, :p]),
+                            DataFrames.rename(data["RPS_S1"], [:r, :p, :s]),
                             on = [:r, :p],
                         ),
                         on = [:r, :p, :t],
                     ),
-                    rename(data["RS_FR"][:, Not(:value)], [:r, :s1, :s]),
+                    DataFrames.rename(data["RS_FR"][:, DataFrames.Not(:value)], [:r, :s1, :s]),
                     on = [:r, :s1, :s],
                 ),
             )
@@ -112,10 +112,10 @@ function compute_indexes(data)
             eachrow(
                 filter(
                     :bd => f -> f == "LO",
-                    rename(data["RCS_COMBAL"], [:r, :t, :c, :s, :bd]),
+                    DataFrames.rename(data["RCS_COMBAL"], [:r, :t, :c, :s, :bd]),
                 )[
                     :,
-                    Not(:bd),
+                    DataFrames.Not(:bd),
                 ],
             )
         ),
@@ -125,10 +125,10 @@ function compute_indexes(data)
             eachrow(
                 filter(
                     :bd => f -> f == "FX",
-                    rename(data["RCS_COMBAL"], [:r, :t, :c, :s, :bd]),
+                    DataFrames.rename(data["RCS_COMBAL"], [:r, :t, :c, :s, :bd]),
                 )[
                     :,
-                    Not(:bd),
+                    DataFrames.Not(:bd),
                 ],
             )
         ),
@@ -139,10 +139,10 @@ function compute_indexes(data)
             eachrow(
                 filter(
                     :bd => f -> f == "FX",
-                    rename(data["RCS_COMPRD"], [:r, :t, :c, :s, :bd]),
+                    DataFrames.rename(data["RCS_COMPRD"], [:r, :t, :c, :s, :bd]),
                 )[
                     :,
-                    Not(:bd),
+                    DataFrames.Not(:bd),
                 ],
             )
         ),
@@ -151,9 +151,9 @@ function compute_indexes(data)
     indices["EQ_STGTSS"] = Set(
         Tuple.(
             eachrow(
-                innerjoin(
-                    rename(data["RTP_VINTYR"], [:r, :v, :t, :p]),
-                    rename(data["RPS_STG"], [:r, :p, :s]),
+                DataFrames.innerjoin(
+                    DataFrames.rename(data["RTP_VINTYR"], [:r, :v, :t, :p]),
+                    DataFrames.rename(data["RPS_STG"], [:r, :p, :s]),
                     on = [:r, :p],
                 ),
             )
@@ -165,8 +165,8 @@ function compute_indexes(data)
         Tuple.(
             eachrow(
                 vcat(
-                    rename(data["RCS_COMPRD"], [:r, :t, :c, :s, :bd]),
-                    rename(data["RCS_COMBAL"], [:r, :t, :c, :s, :bd]),
+                    DataFrames.rename(data["RCS_COMPRD"], [:r, :t, :c, :s, :bd]),
+                    DataFrames.rename(data["RCS_COMBAL"], [:r, :t, :c, :s, :bd]),
                 )[
                     :,
                     [:r, :t, :c, :s],
@@ -176,23 +176,23 @@ function compute_indexes(data)
     )
     indices["var_ComNet"] = indices["var_ComPrd"]
     indices["var_PrcCap"] =
-        Set(Tuple.(eachrow(rename(data["RTP"], [:r, :y, :p])[:, [:r, :y, :p]])))
+        Set(Tuple.(eachrow(DataFrames.rename(data["RTP"], [:r, :y, :p])[:, [:r, :y, :p]])))
     indices["var_PrcNcap"] = indices["var_PrcCap"]
     indices["var_PrcAct"] = Set(
         Tuple.(
             eachrow(
-                innerjoin(vars_base, rename(data["PRC_TS"], [:r, :p, :s]), on = [:r, :p]),
+                DataFrames.innerjoin(vars_base, DataFrames.rename(data["PRC_TS"], [:r, :p, :s]), on = [:r, :p]),
             )
         ),
     )
     indices["var_PrcFlo"] = Set(
         Tuple.(
             eachrow(
-                innerjoin(
+                DataFrames.innerjoin(
                     vars_base,
-                    innerjoin(
-                        rename(data["RP_FLO"], [:r, :p]),
-                        rename(data["RPCS_VAR"], [:r, :p, :c, :s]),
+                    DataFrames.innerjoin(
+                        DataFrames.rename(data["RP_FLO"], [:r, :p]),
+                        DataFrames.rename(data["RPCS_VAR"], [:r, :p, :c, :s]),
                         on = [:r, :p],
                     ),
                     on = [:r, :p],
@@ -203,11 +203,11 @@ function compute_indexes(data)
     indices["var_IreFlo"] = Set(
         Tuple.(
             eachrow(
-                innerjoin(
-                    innerjoin(vars_base, rename(data["RP_IRE"], [:r, :p]), on = [:r, :p]),
-                    innerjoin(
-                        rename(data["RPC_IRE"], [:r, :p, :c, :ie]),
-                        rename(data["PRC_TS"], [:r, :p, :s]),
+                DataFrames.innerjoin(
+                    DataFrames.innerjoin(vars_base, DataFrames.rename(data["RP_IRE"], [:r, :p]), on = [:r, :p]),
+                    DataFrames.innerjoin(
+                        DataFrames.rename(data["RPC_IRE"], [:r, :p, :c, :ie]),
+                        DataFrames.rename(data["PRC_TS"], [:r, :p, :s]),
                         on = [:r, :p],
                     )[
                         :,
@@ -221,11 +221,11 @@ function compute_indexes(data)
     indices["var_StgFlo"] = Set(
         Tuple.(
             eachrow(
-                innerjoin(
-                    innerjoin(vars_base, rename(data["RP_STG"], [:r, :p]), on = [:r, :p]),
-                    innerjoin(
-                        rename(data["TOP"], [:r, :p, :c, :io]),
-                        rename(data["PRC_TS"], [:r, :p, :s]),
+                DataFrames.innerjoin(
+                    DataFrames.innerjoin(vars_base, DataFrames.rename(data["RP_STG"], [:r, :p]), on = [:r, :p]),
+                    DataFrames.innerjoin(
+                        DataFrames.rename(data["TOP"], [:r, :p, :c, :io]),
+                        DataFrames.rename(data["PRC_TS"], [:r, :p, :s]),
                         on = [:r, :p],
                     )[
                         :,
@@ -236,6 +236,5 @@ function compute_indexes(data)
             )
         ),
     )
-
     return indices
 end

--- a/src/compute_sets.jl
+++ b/src/compute_sets.jl
@@ -1,98 +1,82 @@
 # Requires DataFrames
 
-function compute_sets(data)
-
-    global LINTY = Dict{Tuple{String,Int16,String},Vector{Int16}}(
-        (g.R[1], g.T[1], g.CUR[1]) => g.ALLYEAR for
-        g in groupby(data["IS_LINT"], [:R, :T, :CUR])
+function compute_sets(data::Dict{String})
+    return (;
+        LINTY = Dict{Tuple{String,Int16,String},Vector{Int16}}(
+            (g.R[1], g.T[1], g.CUR[1]) => g.ALLYEAR for
+            g in DataFrames.groupby(data["IS_LINT"], [:R, :T, :CUR])
+        ),
+        RTP_VNT = Dict{Tuple{String,Int16,String},Vector{Int16}}(
+            (g.ALL_REG[1], g.ALLYEAR2[1], g.PRC[1]) => g.ALLYEAR for
+            g in DataFrames.groupby(data["RTP_VINTYR"], [:ALL_REG, :ALLYEAR2, :PRC])
+        ),
+        RTV_PRC = Dict{Tuple{String,Int16,Int16},Vector{String}}(
+            (g.ALL_REG[1], g.ALLYEAR2[1], g.ALLYEAR[1]) => g.PRC for
+            g in DataFrames.groupby(data["RTP_VINTYR"], [:ALL_REG, :ALLYEAR2, :ALLYEAR])
+        ),
+        RTP_CPT = Dict{Tuple{String,Int16,String},Vector{Int16}}(
+            (g.R[1], g.T[1], g.PRC[1]) => g.ALLYEAR for
+            g in DataFrames.groupby(data["RTP_CPTYR"], [:R, :T, :PRC])
+        ),
+        RTP_AFS = Dict{Tuple{String,Int16,String,String},Vector{String}}(
+            (g.R[1], g.T[1], g.P[1], g.BD[1]) => g.S for
+            g in DataFrames.groupby(data["AFS"], [:R, :T, :P, :BD])
+        ),
+        RP_TS = Dict{Tuple{String,String},Vector{String}}(
+            (g.ALL_REG[1], g.PRC[1]) => g.ALL_TS for
+            g in DataFrames.groupby(data["PRC_TS"], [:ALL_REG, :PRC])
+        ),
+        RP_S1 = Dict{Tuple{String,String},Vector{String}}(
+            (g.R[1], g.P[1]) => g.ALL_TS for g in DataFrames.groupby(data["RPS_S1"], [:R, :P])
+        ),
+        RP_PGC = Dict{Tuple{String,String},Vector{String}}(
+            (g.R[1], g.P[1]) => g.C for g in DataFrames.groupby(data["RPC_PG"], [:R, :P])
+        ),
+        RP_CIE = Dict{Tuple{String,String},Vector{Tuple{String,String}}}(
+            (g.ALL_REG[1], g.P[1]) => Tuple.(eachrow(g[!, [:C, :IE]])) for
+            g in DataFrames.groupby(data["RPC_IRE"], [:ALL_REG, :P])
+        ),
+        RP_CIO = Dict{Tuple{String,String},Vector{Tuple{String,String}}}(
+            (g.REG[1], g.PRC[1]) => Tuple.(eachrow(g[!, [:COM, :IO]])) for g in DataFrames.groupby(
+                DataFrames.innerjoin(data["TOP"], data["RP_FLO"], on = [:REG => :R, :PRC => :P]),
+                [:REG, :PRC],
+            )
+        ),
+        RPC_TS = Dict{Tuple{String,String,String},Vector{String}}(
+            (g.R[1], g.P[1], g.C[1]) => g.ALL_TS for
+            g in DataFrames.groupby(data["RPCS_VAR"], [:R, :P, :C])
+        ),
+        RPIO_C = Dict{Tuple{String,String,String},Vector{String}}(
+            (g.REG[1], g.PRC[1], g.IO[1]) => g.COM for g in DataFrames.groupby(
+                DataFrames.innerjoin(data["TOP"], data["RP_FLO"], on = [:REG => :R, :PRC => :P]),
+                [:REG, :PRC, :IO],
+            )
+        ),
+        RCIO_P = Dict{Tuple{String,String,String},Vector{String}}(
+            (g.REG[1], g.COM[1], g.IO[1]) => g.PRC for g in DataFrames.groupby(
+                DataFrames.innerjoin(data["TOP"], data["RP_FLO"], on = [:REG => :R, :PRC => :P]),
+                [:REG, :COM, :IO],
+            )
+        ),
+        RCIE_P = Dict{Tuple{String,String,String},Vector{String}}(
+            (g.ALL_REG[1], g.C[1], g.IE[1]) => g.P for
+            g in DataFrames.groupby(data["RPC_IRE"], [:ALL_REG, :C, :IE])
+        ),
+        RP_ACE = if isempty(data["RPC_ACE"])
+            nothing
+        else
+            Dict{Tuple{String,String},Vector{String}}(
+                (g.REG[1], g.PRC[1]) => g.CG for g in DataFrames.groupby(data["RPC_ACE"], [:REG, :PRC])
+            )
+        end,
+        R_P = Dict{String,Vector{String}}(g.R[1] => g.P for g in DataFrames.groupby(data["RP"], :R)),
+        R_C = Dict{String,Vector{String}}(g.R[1] => g.C for g in DataFrames.groupby(data["RC"], :R)),
+        RP_C = Dict{Tuple{String,String},Vector{String}}(
+            (g.R[1], g.P[1]) => g.C for g in DataFrames.groupby(data["RPC"], [:R, :P])
+        ),
+        R_CPT = Dict{String,Vector{Tuple{Int16,Int16,String}}}(
+            g.R[1] => Tuple.(eachrow(g[!, [:ALLYEAR, :T, :PRC]])) for
+            g in DataFrames.groupby(data["RTP_CPTYR"], :R)
+        ),
     )
-
-    global RTP_VNT = Dict{Tuple{String,Int16,String},Vector{Int16}}(
-        (g.ALL_REG[1], g.ALLYEAR2[1], g.PRC[1]) => g.ALLYEAR for
-        g in groupby(data["RTP_VINTYR"], [:ALL_REG, :ALLYEAR2, :PRC])
-    )
-
-    global RTV_PRC = Dict{Tuple{String,Int16,Int16},Vector{String}}(
-        (g.ALL_REG[1], g.ALLYEAR2[1], g.ALLYEAR[1]) => g.PRC for
-        g in groupby(data["RTP_VINTYR"], [:ALL_REG, :ALLYEAR2, :ALLYEAR])
-    )
-
-    global RTP_CPT = Dict{Tuple{String,Int16,String},Vector{Int16}}(
-        (g.R[1], g.T[1], g.PRC[1]) => g.ALLYEAR for
-        g in groupby(data["RTP_CPTYR"], [:R, :T, :PRC])
-    )
-
-    global RTP_AFS = Dict{Tuple{String,Int16,String,String},Vector{String}}(
-        (g.R[1], g.T[1], g.P[1], g.BD[1]) => g.S for
-        g in groupby(data["AFS"], [:R, :T, :P, :BD])
-    )
-
-    global RP_TS = Dict{Tuple{String,String},Vector{String}}(
-        (g.ALL_REG[1], g.PRC[1]) => g.ALL_TS for
-        g in groupby(data["PRC_TS"], [:ALL_REG, :PRC])
-    )
-
-    global RP_S1 = Dict{Tuple{String,String},Vector{String}}(
-        (g.R[1], g.P[1]) => g.ALL_TS for g in groupby(data["RPS_S1"], [:R, :P])
-    )
-
-    global RP_PGC = Dict{Tuple{String,String},Vector{String}}(
-        (g.R[1], g.P[1]) => g.C for g in groupby(data["RPC_PG"], [:R, :P])
-    )
-
-    global RP_CIE = Dict{Tuple{String,String},Vector{Tuple{String,String}}}(
-        (g.ALL_REG[1], g.P[1]) => Tuple.(eachrow(g[!, [:C, :IE]])) for
-        g in groupby(data["RPC_IRE"], [:ALL_REG, :P])
-    )
-
-    global RP_CIO = Dict{Tuple{String,String},Vector{Tuple{String,String}}}(
-        (g.REG[1], g.PRC[1]) => Tuple.(eachrow(g[!, [:COM, :IO]])) for g in groupby(
-            innerjoin(data["TOP"], data["RP_FLO"], on = [:REG => :R, :PRC => :P]),
-            [:REG, :PRC],
-        )
-    )
-
-    global RPC_TS = Dict{Tuple{String,String,String},Vector{String}}(
-        (g.R[1], g.P[1], g.C[1]) => g.ALL_TS for
-        g in groupby(data["RPCS_VAR"], [:R, :P, :C])
-    )
-
-    global RPIO_C = Dict{Tuple{String,String,String},Vector{String}}(
-        (g.REG[1], g.PRC[1], g.IO[1]) => g.COM for g in groupby(
-            innerjoin(data["TOP"], data["RP_FLO"], on = [:REG => :R, :PRC => :P]),
-            [:REG, :PRC, :IO],
-        )
-    )
-
-    global RCIO_P = Dict{Tuple{String,String,String},Vector{String}}(
-        (g.REG[1], g.COM[1], g.IO[1]) => g.PRC for g in groupby(
-            innerjoin(data["TOP"], data["RP_FLO"], on = [:REG => :R, :PRC => :P]),
-            [:REG, :COM, :IO],
-        )
-    )
-
-    global RCIE_P = Dict{Tuple{String,String,String},Vector{String}}(
-        (g.ALL_REG[1], g.C[1], g.IE[1]) => g.P for
-        g in groupby(data["RPC_IRE"], [:ALL_REG, :C, :IE])
-    )
-
-    global RP_ACE =
-        !isnothing(RPC_ACE) ?
-        Dict{Tuple{String,String},Vector{String}}(
-            (g.REG[1], g.PRC[1]) => g.CG for g in groupby(data["RPC_ACE"], [:REG, :PRC])
-        ) : nothing
-
-    global R_P = Dict{String,Vector{String}}(g.R[1] => g.P for g in groupby(data["RP"], :R))
-
-    global R_C = Dict{String,Vector{String}}(g.R[1] => g.C for g in groupby(data["RC"], :R))
-
-    global RP_C = Dict{Tuple{String,String},Vector{String}}(
-        (g.R[1], g.P[1]) => g.C for g in groupby(data["RPC"], [:R, :P])
-    )
-
-    global R_CPT = Dict{String,Vector{Tuple{Int16,Int16,String}}}(
-        g.R[1] => Tuple.(eachrow(g[!, [:ALLYEAR, :T, :PRC]])) for
-        g in groupby(data["RTP_CPTYR"], :R)
-    )
-
 end

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -1,237 +1,252 @@
 # Requires JuMP
 
-function create_constraints(model, indices)
+function create_constraints!(model, indices, data, sets)
+    # Variables
+    RegObj = model[:RegObj]
+    PrcCap = model[:PrcCap]
+    ComPrd = model[:ComPrd]
+    ComNet = model[:ComNet]
+    PrcNcap = model[:PrcNcap]
+    PrcAct = model[:PrcAct]
+    PrcFlo = model[:PrcFlo]
+    IreFlo = model[:IreFlo]
+    StgFlo = model[:StgFlo]
+    # Parameters
+    MILE = model[:MILE]
+
     # Objective function constituents
-    @constraint(
+    JuMP.@constraint(
         model,
-        EQ_OBJINV[(r, cur) in RDCUR],
-        sum(
+        EQ_OBJINV[(r, cur) in data[:RDCUR]],
+        RegObj["OBJINV", r, cur] == sum(
+            data[:OBJ_PVT][r, t, cur] *
+            data[:COEF_CPT][r, v, t, p] *
+            get(data[:COEF_OBINV], (r, v, p, cur), 0) *
             (
-                OBJ_PVT[r, t, cur] *
-                COEF_CPT[r, v, t, p] *
-                get(COEF_OBINV, (r, v, p, cur), 0) *
-                ((v in MILEYR ? PrcNcap[(r, v, p)] : 0) + get(NCAP_PASTI, (r, v, p), 0))
-            ) for (v, t, p) in R_CPT[r]
-        ) == RegObj["OBJINV", r, cur]
+                (v in data[:MILEYR] ? PrcNcap[(r, v, p)] : 0) +
+                get(data[:NCAP_PASTI], (r, v, p), 0)
+            )
+            for (v, t, p) in sets.R_CPT[r]
+        )
     )
 
-    @constraint(
+    JuMP.@constraint(
         model,
-        EQ_OBJFIX[(r, cur) in RDCUR],
+        EQ_OBJFIX[(r, cur) in data[:RDCUR]],
         sum(
             (
-                OBJ_PVT[r, t, cur] *
-                COEF_CPT[r, v, t, p] *
-                get(COEF_OBFIX, (r, v, p, cur), 0) *
-                ((v in MILEYR ? PrcNcap[(r, v, p)] : 0) + get(NCAP_PASTI, (r, v, p), 0))
-            ) for (v, t, p) in R_CPT[r]
+                data[:OBJ_PVT][r, t, cur] *
+                data[:COEF_CPT][r, v, t, p] *
+                get(data[:COEF_OBFIX], (r, v, p, cur), 0) *
+                ((v in data[:MILEYR] ? PrcNcap[(r, v, p)] : 0) + get(data[:NCAP_PASTI], (r, v, p), 0))
+            ) for (v, t, p) in sets.R_CPT[r]
         ) == RegObj["OBJFIX", r, cur]
     )
 
-    @constraint(
+    JuMP.@constraint(
         model,
-        EQ_OBJVAR[(r, cur) in RDCUR],
+        EQ_OBJVAR[(r, cur) in data[:RDCUR]],
         sum(
             sum(
                 sum(
-                    OBJ_LINT[r, t, y, cur] * get(OBJ_ACOST, (r, p, cur, y), 0) for
-                    y in LINTY[r, t, cur]
+                    data[:OBJ_LINT][r, t, y, cur] * get(data[:OBJ_ACOST], (r, p, cur, y), 0) for
+                    y in sets.LINTY[r, t, cur]
                 ) * sum(
-                    PrcAct[(r, v, t, p, s)] * ((r, p) in RP_STG ? RS_STGAV[r, s] : 1) for
-                    v in get(RTP_VNT, (r, t, p), Set()) for s in RP_TS[r, p]
+                    PrcAct[(r, v, t, p, s)] * ((r, p) in data[:RP_STG] ? data[:RS_STGAV][r, s] : 1) for
+                    v in get(sets.RTP_VNT, (r, t, p), Set()) for s in sets.RP_TS[r, p]
                 ) + (
-                    (r, t, p, cur) in RTP_IPRI ?
+                    (r, t, p, cur) in data[:RTP_IPRI] ?
                     sum(
                         sum(
-                            OBJ_LINT[r, t, y, cur] * OBJ_IPRIC[r, y, p, c, s, ie, cur] for
-                            y in LINTY[r, t, cur]
+                            data[:OBJ_LINT][r, t, y, cur] * data[:OBJ_IPRIC][r, y, p, c, s, ie, cur] for
+                            y in sets.LINTY[r, t, cur]
                         ) * sum(
                             IreFlo[(r, v, t, p, c, s, ie)] for
-                            v in get(RTP_VNT, (r, t, p), Set())
-                        ) for s in RP_TS[r, p] for (c, ie) in RP_CIE[r, p]
+                            v in get(sets.RTP_VNT, (r, t, p), Set())
+                        ) for s in sets.RP_TS[r, p] for (c, ie) in sets.RP_CIE[r, p]
                     ) : 0
-                ) for t in MILEYR if (r, t, p) in RTP_VARA
-            ) for p in R_P[r]
+                ) for t in data[:MILEYR] if (r, t, p) in data[:RTP_VARA]
+            ) for p in sets.R_P[r]
         ) == RegObj["OBJVAR", r, cur]
     )
 
     # %% Activity to Primary Group
-    @constraint(
+    JuMP.@constraint(
         model,
         EQ_ACTFLO[(r, v, t, p, s) in indices["EQ_ACTFLO"]],
-        ((r, t, p) in RTP_VARA ? PrcAct[(r, v, t, p, s)] : 0) == sum(
+        ((r, t, p) in data[:RTP_VARA] ? PrcAct[(r, v, t, p, s)] : 0) == sum(
             (
-                (r, p) in RP_IRE ?
+                (r, p) in data[:RP_IRE] ?
                 sum(
-                    IreFlo[(r, v, t, p, c, s, ie)] for ie in IMPEXP if (r, p, ie) in RP_AIRE
+                    IreFlo[(r, v, t, p, c, s, ie)] for ie in IMPEXP if (r, p, ie) in data[:RP_AIRE]
                 ) : PrcFlo[(r, v, t, p, c, s)]
-            ) for c in RP_PGC[r, p]
+            ) for c in sets.RP_PGC[r, p]
         )
     )
 
     # %% Activity to Capacity
-    @constraint(
+    JuMP.@constraint(
         model,
         EQL_CAPACT[(r, v, y, p, s) in indices["EQL_CAPACT"]],
         (
-            (r, p) in RP_STG ?
+            (r, p) in data[:RP_STG] ?
             sum(
                 PrcAct[(r, v, y, p, ts)] *
-                RS_FR[r, ts, s] *
-                exp(isnothing(PRC_SC) ? 0 : get(PRC_SC, (r, p), 0)) / RS_STGPRD[r, s] for
-                ts in RP_TS[r, p] if haskey(RS_FR, (r, s, ts))
+                data[:RS_FR][r, ts, s] *
+                exp(isnothing(data[:PRC_SC]) ? 0 : get(data[:PRC_SC], (r, p), 0)) / data[:RS_STGPRD][r, s] for
+                ts in sets.RP_TS[r, p] if haskey(data[:RS_FR], (r, s, ts))
             ) :
             sum(
-                PrcAct[(r, v, y, p, ts)] for ts in RP_TS[r, p] if haskey(RS_FR, (r, s, ts))
+                PrcAct[(r, v, y, p, ts)] for ts in sets.RP_TS[r, p] if haskey(data[:RS_FR], (r, s, ts))
             )
         ) <= (
-            ((r, p) in RP_STG ? 1 : G_YRFR[r, s]) *
-            PRC_CAPACT[r, p] *
+            ((r, p) in data[:RP_STG] ? 1 : data[:G_YRFR][r, s]) *
+            data[:PRC_CAPACT][r, p] *
             (
-                (r, p) in PRC_VINT ?
-                COEF_AF[r, v, y, p, s, "UP"] *
-                COEF_CPT[r, v, y, p] *
-                (MILE[v] * PrcNcap[(r, v, p)] + get(NCAP_PASTI, (r, v, p), 0)) :
+                (r, p) in data[:PRC_VINT] ?
+                data[:COEF_AF][r, v, y, p, s, "UP"] *
+                data[:COEF_CPT][r, v, y, p] *
+                (MILE[v] * PrcNcap[(r, v, p)] + get(data[:NCAP_PASTI], (r, v, p), 0)) :
                 sum(
-                    COEF_AF[r, m, y, p, s, "UP"] *
-                    COEF_CPT[r, m, y, p] *
-                    ((MILE[m] * PrcNcap[(r, m, p)]) + get(NCAP_PASTI, (r, m, p), 0)) for
-                    m in RTP_CPT[r, y, p]
+                    data[:COEF_AF][r, m, y, p, s, "UP"] *
+                    data[:COEF_CPT][r, m, y, p] *
+                    ((MILE[m] * PrcNcap[(r, m, p)]) + get(data[:NCAP_PASTI], (r, m, p), 0)) for
+                    m in sets.RTP_CPT[r, y, p]
                 )
             )
         )
     )
 
-    @constraint(
+    JuMP.@constraint(
         model,
         EQG_CAPACT[(r, v, y, p, s) in indices["EQG_CAPACT"]],
         (
-            (r, p) in RP_STG ?
+            (r, p) in data[:RP_STG] ?
             sum(
                 PrcAct[(r, v, y, p, ts)] *
-                RS_FR[r, ts, s] *
-                exp(isnothing(PRC_SC) ? 0 : get(PRC_SC, (r, p), 0)) / RS_STGPRD[r, s] for
-                ts in RP_TS[r, p] if haskey(RS_FR, (r, s, ts))
+                data[:RS_FR][r, ts, s] *
+                exp(isnothing(data[:PRC_SC]) ? 0 : get(data[:PRC_SC], (r, p), 0)) / data[:RS_STGPRD][r, s] for
+                ts in sets.RP_TS[r, p] if haskey(data[:RS_FR], (r, s, ts))
             ) :
             sum(
-                PrcAct[(r, v, y, p, ts)] for ts in RP_TS[r, p] if haskey(RS_FR, (r, s, ts))
+                PrcAct[(r, v, y, p, ts)] for ts in sets.RP_TS[r, p] if haskey(data[:RS_FR], (r, s, ts))
             )
         ) >= (
-            ((r, p) in RP_STG ? 1 : G_YRFR[r, s]) *
-            PRC_CAPACT[r, p] *
+            ((r, p) in data[:RP_STG] ? 1 : data[:G_YRFR][r, s]) *
+            data[:PRC_CAPACT][r, p] *
             (
-                (r, p) in PRC_VINT ?
-                COEF_AF[r, v, y, p, s, "LO"] *
-                COEF_CPT[r, v, y, p] *
-                (MILE[v] * PrcNcap[(r, v, p)] + get(NCAP_PASTI, (r, v, p), 0)) :
+                (r, p) in data[:PRC_VINT] ?
+                data[:COEF_AF][r, v, y, p, s, "LO"] *
+                data[:COEF_CPT][r, v, y, p] *
+                (MILE[v] * PrcNcap[(r, v, p)] + get(data[:NCAP_PASTI], (r, v, p), 0)) :
                 sum(
-                    COEF_AF[r, m, y, p, s, "LO"] *
-                    COEF_CPT[r, m, y, p] *
-                    ((MILE[m] * PrcNcap[(r, m, p)]) + get(NCAP_PASTI, (r, m, p), 0)) for
-                    m in RTP_CPT[r, y, p]
+                    data[:COEF_AF][r, m, y, p, s, "LO"] *
+                    data[:COEF_CPT][r, m, y, p] *
+                    ((MILE[m] * PrcNcap[(r, m, p)]) + get(data[:NCAP_PASTI], (r, m, p), 0)) for
+                    m in sets.RTP_CPT[r, y, p]
                 )
             )
         )
     )
 
-    @constraint(
+    JuMP.@constraint(
         model,
         EQE_CAPACT[(r, v, y, p, s) in indices["EQE_CAPACT"]],
         (
-            (r, p) in RP_STG ?
+            (r, p) in data[:RP_STG] ?
             sum(
                 PrcAct[(r, v, y, p, ts)] *
-                RS_FR[r, ts, s] *
-                exp(isnothing(PRC_SC) ? 0 : PRC_SC[r, p]) / RS_STGPRD[r, s] for
-                ts in RP_TS[r, p] if haskey(RS_FR, (r, s, ts))
+                data[:RS_FR][r, ts, s] *
+                exp(isnothing(data[:PRC_SC]) ? 0 : data[:PRC_SC][r, p]) / data[:RS_STGPRD][r, s] for
+                ts in sets.RP_TS[r, p] if haskey(data[:RS_FR], (r, s, ts))
             ) :
             sum(
-                PrcAct[(r, v, y, p, ts)] for ts in RP_TS[r, p] if haskey(RS_FR, (r, s, ts))
+                PrcAct[(r, v, y, p, ts)] for ts in sets.RP_TS[r, p] if haskey(data[:RS_FR], (r, s, ts))
             )
         ) == (
-            ((r, p) in RP_STG ? 1 : G_YRFR[r, s]) *
-            PRC_CAPACT[r, p] *
+            ((r, p) in data[:RP_STG] ? 1 : data[:G_YRFR][r, s]) *
+            data[:PRC_CAPACT][r, p] *
             (
-                (r, p) in PRC_VINT ?
-                COEF_AF[r, v, y, p, s, "FX"] *
-                COEF_CPT[r, v, y, p] *
-                (MILE[v] * PrcNcap[(r, v, p)] + get(NCAP_PASTI, (r, v, p), 0)) :
+                (r, p) in data[:PRC_VINT] ?
+                data[:COEF_AF][r, v, y, p, s, "FX"] *
+                data[:COEF_CPT][r, v, y, p] *
+                (MILE[v] * PrcNcap[(r, v, p)] + get(data[:NCAP_PASTI], (r, v, p), 0)) :
                 sum(
-                    COEF_AF[r, m, y, p, s, "FX"] *
-                    COEF_CPT[r, m, y, p] *
-                    ((MILE[m] * PrcNcap[(r, m, p)]) + get(NCAP_PASTI, (r, m, p), 0)) for
-                    m in RTP_CPT[r, y, p]
+                    data[:COEF_AF][r, m, y, p, s, "FX"] *
+                    data[:COEF_CPT][r, m, y, p] *
+                    ((MILE[m] * PrcNcap[(r, m, p)]) + get(data[:NCAP_PASTI], (r, m, p), 0)) for
+                    m in sets.RTP_CPT[r, y, p]
                 )
             )
         )
     )
 
     # %% Capacity Transfer
-    @constraint(
+    JuMP.@constraint(
         model,
         EQE_CPT[
-            (r, y, p) in RTP
-            (r, y, p) in RTP_VARP || haskey(CAP_BND, (r, y, p, "FX"))
+            (r, y, p) in data[:RTP]
+            (r, y, p) in data[:RTP_VARP] || haskey(data[:CAP_BND], (r, y, p, "FX"))
         ],
-        ((r, y, p) in RTP_VARP ? PrcCap[(r, y, p)] : CAP_BND[r, y, p, "FX"]) == sum(
-            COEF_CPT[r, v, y, p] *
-            ((MILE[v] * PrcNcap[(r, v, p)]) + get(NCAP_PASTI, (r, v, p), 0)) for
-            v in get(RTP_CPT, (r, y, p), Set())
+        ((r, y, p) in data[:RTP_VARP] ? PrcCap[(r, y, p)] : data[:CAP_BND][r, y, p, "FX"]) == sum(
+            data[:COEF_CPT][r, v, y, p] *
+            ((MILE[v] * PrcNcap[(r, v, p)]) + get(data[:NCAP_PASTI], (r, v, p), 0)) for
+            v in get(sets.RTP_CPT, (r, y, p), Set())
         )
     )
 
-    @constraint(
+    JuMP.@constraint(
         model,
         EQL_CPT[
-            (r, y, p) in RTP
-            !((r, y, p) in RTP_VARP) && haskey(CAP_BND, (r, y, p, "LO"))
+            (r, y, p) in data[:RTP]
+            !((r, y, p) in data[:RTP_VARP]) && haskey(data[:CAP_BND], (r, y, p, "LO"))
         ],
-        ((r, y, p) in RTP_VARP ? PrcCap[(r, y, p)] : CAP_BND[r, y, p, "LO"]) <= sum(
-            COEF_CPT[r, v, y, p] *
-            ((MILE[v] * PrcNcap[(r, v, p)]) + get(NCAP_PASTI, (r, v, p), 0)) for
-            v in get(RTP_CPT, (r, y, p), Set())
+        ((r, y, p) in data[:RTP_VARP] ? PrcCap[(r, y, p)] : data[:CAP_BND][r, y, p, "LO"]) <= sum(
+            data[:COEF_CPT][r, v, y, p] *
+            ((MILE[v] * PrcNcap[(r, v, p)]) + get(data[:NCAP_PASTI], (r, v, p), 0)) for
+            v in get(sets.RTP_CPT, (r, y, p), Set())
         )
     )
 
-    @constraint(
+    JuMP.@constraint(
         model,
         EQG_CPT[
-            (r, y, p) in RTP
-            !((r, y, p) in RTP_VARP) && haskey(CAP_BND, (r, y, p, "UP"))
+            (r, y, p) in data[:RTP]
+            !((r, y, p) in data[:RTP_VARP]) && haskey(data[:CAP_BND], (r, y, p, "UP"))
         ],
-        ((r, y, p) in RTP_VARP ? PrcCap[(r, y, p)] : CAP_BND[r, y, p, "UP"]) >= sum(
-            COEF_CPT[r, v, y, p] *
-            ((MILE[v] * PrcNcap[(r, v, p)]) + get(NCAP_PASTI, (r, v, p), 0)) for
-            v in get(RTP_CPT, (r, y, p), Set())
+        ((r, y, p) in data[:RTP_VARP] ? PrcCap[(r, y, p)] : data[:CAP_BND][r, y, p, "UP"]) >= sum(
+            data[:COEF_CPT][r, v, y, p] *
+            ((MILE[v] * PrcNcap[(r, v, p)]) + get(data[:NCAP_PASTI], (r, v, p), 0)) for
+            v in get(sets.RTP_CPT, (r, y, p), Set())
         )
     )
 
     # %% Process Flow Shares
-    @expression(
+    JuMP.@expression(
         model,
         EXPR_FLOSHR[(r, v, p, c, cg, s, l, t) in indices["EXPR_FLOSHR"]],
         sum(
-            FLO_SHAR[r, v, p, c, cg, s, l] * sum(
-                PrcFlo[(r, v, t, p, com, ts)] * get(RS_FR, (r, s, ts), 0) for
-                com in RPIO_C[r, p, io] for
-                ts in RPC_TS[r, p, c] if (r, cg, com) in COM_GMAP
-            ) for io in INOUT if c in RPIO_C[r, p, io]
+            data[:FLO_SHAR][r, v, p, c, cg, s, l] * sum(
+                PrcFlo[(r, v, t, p, com, ts)] * get(data[:RS_FR], (r, s, ts), 0) for
+                com in sets.RPIO_C[r, p, io] for
+                ts in sets.RPC_TS[r, p, c] if (r, cg, com) in data[:COM_GMAP]
+            ) for io in INOUT if c in sets.RPIO_C[r, p, io]
         )
     )
 
-    @constraint(
+    JuMP.@constraint(
         model,
         EQL_FLOSHR[(r, v, p, c, cg, s, l, t) in indices["EQL_FLOSHR"]],
         EXPR_FLOSHR[(r, v, p, c, cg, s, l, t)] <= PrcFlo[(r, v, t, p, c, s)]
     )
 
-    @constraint(
+    JuMP.@constraint(
         model,
         EQG_FLOSHR[(r, v, p, c, cg, s, l, t) in indices["EQG_FLOSHR"]],
         EXPR_FLOSHR[(r, v, p, c, cg, s, l, t)] >= PrcFlo[(r, v, t, p, c, s)]
     )
 
-    @constraint(
+    JuMP.@constraint(
         model,
         EQE_FLOSHR[(r, v, p, c, cg, s, l, t) in indices["EQE_FLOSHR"]],
         EXPR_FLOSHR[(r, v, p, c, cg, s, l, t)] == PrcFlo[(r, v, t, p, c, s)]
@@ -239,299 +254,298 @@ function create_constraints(model, indices)
 
 
     # %% Activity efficiency:
-    @constraint(
+    JuMP.@constraint(
         model,
         EQE_ACTEFF[(r, p, cg, io, t, v, s) in indices["EQE_ACTEFF"]],
         (
-            !isnothing(RP_ACE) ?
+            !isnothing(sets.RP_ACE) ?
             sum(
                 sum(
                     PrcFlo[(r, v, t, p, c, ts)] *
-                    get(ACT_EFF, (r, v, p, c, ts), 1) *
-                    get(RS_FR, (r, s, ts), 0) *
-                    (1 + (!isnothing(RTCS_FR) ? get(RTCS_FR, (r, t, c, s, ts), 0) : 0)) for
-                    ts in RPC_TS[r, p, c]
-                ) for c in RP_ACE[r, p] if (r, cg, c) in COM_GMAP
+                    get(data[:ACT_EFF], (r, v, p, c, ts), 1) *
+                    get(data[:RS_FR], (r, s, ts), 0) *
+                    (1 + (!isnothing(data[:RTCS_FR]) ? get(data[:RTCS_FR], (r, t, c, s, ts), 0) : 0)) for
+                    ts in sets.RPC_TS[r, p, c]
+                ) for c in sets.RP_ACE[r, p] if (r, cg, c) in data[:COM_GMAP]
             ) : 0
         ) == sum(
-            get(RS_FR, (r, s, ts), 0) * (
-                (r, p) in RP_PGFLO ?
+            get(data[:RS_FR], (r, s, ts), 0) * (
+                (r, p) in data[:RP_PGFLO] ?
                 sum(
                     (
-                        (r, p) in RP_PGACT ? PrcAct[(r, v, t, p, ts)] :
-                        PrcFlo[(r, v, t, p, c, ts)] / PRC_ACTFLO[r, v, p, c]
-                    ) / get(ACT_EFF, (r, v, p, c, ts), 1) *
-                    (1 + (!isnothing(RTCS_FR) ? get(RTCS_FR, (r, t, c, s, ts), 0) : 0)) for
-                    c in RP_PGC[r, p]
+                        (r, p) in data[:RP_PGACT] ? PrcAct[(r, v, t, p, ts)] :
+                        PrcFlo[(r, v, t, p, c, ts)] / data[:PRC_ACTFLO][r, v, p, c]
+                    ) / get(data[:ACT_EFF], (r, v, p, c, ts), 1) *
+                    (1 + (!isnothing(data[:RTCS_FR]) ? get(data[:RTCS_FR], (r, t, c, s, ts), 0) : 0)) for
+                    c in sets.RP_PGC[r, p]
                 ) : PrcAct[(r, v, t, p, ts)]
-            ) / max(1e-6, get(ACT_EFF, (r, v, p, cg, ts), 1)) for ts in RP_TS[r, p]
+            ) / max(1e-6, get(data[:ACT_EFF], (r, v, p, cg, ts), 1)) for ts in sets.RP_TS[r, p]
         )
     )
 
     # %% Process Transformation
-    @constraint(
+    JuMP.@constraint(
         model,
         EQ_PTRANS[(r, p, cg1, cg2, s1, t, v, s) in indices["EQ_PTRANS"]],
         sum(
             sum(
                 PrcFlo[(r, v, t, p, c, ts)] *
-                get(RS_FR, (r, s, ts), 0) *
-                (1 + (!isnothing(RTCS_FR) ? get(RTCS_FR, (r, t, c, s, ts), 0) : 0)) for
-                ts in RPC_TS[r, p, c]
-            ) for io in INOUT for c in RPIO_C[r, p, io] if (r, cg2, c) in COM_GMAP
+                get(data[:RS_FR], (r, s, ts), 0) *
+                (1 + (!isnothing(data[:RTCS_FR]) ? get(data[:RTCS_FR], (r, t, c, s, ts), 0) : 0)) for
+                ts in sets.RPC_TS[r, p, c]
+            ) for io in INOUT for c in sets.RPIO_C[r, p, io] if (r, cg2, c) in data[:COM_GMAP]
         ) == sum(
-            get(COEF_PTRAN, (r, v, p, cg1, c, cg2, ts), 0) *
-            get(RS_FR, (r, s, ts), 0) *
-            (1 + (!isnothing(RTCS_FR) ? get(RTCS_FR, (r, t, c, s, ts), 0) : 0)) *
-            PrcFlo[(r, v, t, p, c, ts)] for io in INOUT for c in RPIO_C[r, p, io] for
-            ts in RPC_TS[r, p, c]
+            get(data[:COEF_PTRAN], (r, v, p, cg1, c, cg2, ts), 0) *
+            get(data[:RS_FR], (r, s, ts), 0) *
+            (1 + (!isnothing(data[:RTCS_FR]) ? get(data[:RTCS_FR], (r, t, c, s, ts), 0) : 0)) *
+            PrcFlo[(r, v, t, p, c, ts)] for io in INOUT for c in sets.RPIO_C[r, p, io] for
+            ts in sets.RPC_TS[r, p, c]
         )
     )
 
     # %% Commodity Balance - Greater
-
-    @constraint(
+    JuMP.@constraint(
         model,
         EQG_COMBAL[(r, t, c, s) in indices["EQG_COMBAL"]],
         (
-            !isnothing(RHS_COMPRD) && ((r, t, c, s) in RHS_COMPRD) ? ComPrd[(r, t, c, s)] :
+            !isnothing(data[:RHS_COMPRD]) && ((r, t, c, s) in data[:RHS_COMPRD]) ? ComPrd[(r, t, c, s)] :
             (
                 sum(
                     (
-                        (r, p, c) in RPC_STG ?
+                        (r, p, c) in data[:RPC_STG] ?
                         sum(
                             sum(
                                 StgFlo[(r, v, t, p, c, ts, "OUT")] *
-                                get(RS_FR, (r, s, ts), 0) *
+                                get(data[:RS_FR], (r, s, ts), 0) *
                                 (
                                     1 + (
-                                        !isnothing(RTCS_FR) ?
-                                        get(RTCS_FR, (r, t, c, s, ts), 0) : 0
+                                        !isnothing(data[:RTCS_FR]) ?
+                                        get(data[:RTCS_FR], (r, t, c, s, ts), 0) : 0
                                     )
                                 ) *
-                                STG_EFF[r, v, p] for v in get(RTP_VNT, (r, t, p), Set())
-                            ) for ts in RPC_TS[r, p, c]
+                                data[:STG_EFF][r, v, p] for v in get(sets.RTP_VNT, (r, t, p), Set())
+                            ) for ts in sets.RPC_TS[r, p, c]
                         ) :
                         sum(
                             sum(
                                 PrcFlo[(r, v, t, p, c, ts)] *
-                                get(RS_FR, (r, s, ts), 0) *
+                                get(data[:RS_FR], (r, s, ts), 0) *
                                 (
                                     1 + (
-                                        !isnothing(RTCS_FR) ?
-                                        get(RTCS_FR, (r, t, c, s, ts), 0) : 0
+                                        !isnothing(data[:RTCS_FR]) ?
+                                        get(data[:RTCS_FR], (r, t, c, s, ts), 0) : 0
                                     )
-                                ) for v in get(RTP_VNT, (r, t, p), Set());
+                                ) for v in get(sets.RTP_VNT, (r, t, p), Set());
                                 init = 0,
-                            ) for ts in RPC_TS[r, p, c]
+                            ) for ts in sets.RPC_TS[r, p, c]
                         )
-                    ) for p in get(RCIO_P, (r, c, "OUT"), Set()) if (r, t, p) in RTP_VARA;
+                    ) for p in get(sets.RCIO_P, (r, c, "OUT"), Set()) if (r, t, p) in data[:RTP_VARA];
                     init = 0,
                 ) + sum(
                     sum(
                         sum(
                             IreFlo[(r, v, t, p, c, ts, "IMP")] *
-                            get(RS_FR, (r, s, ts), 0) *
+                            get(data[:RS_FR], (r, s, ts), 0) *
                             (
                                 1 + (
-                                    !isnothing(RTCS_FR) ?
-                                    get(RTCS_FR, (r, t, c, s, ts), 0) : 0
+                                    !isnothing(data[:RTCS_FR]) ?
+                                    get(data[:RTCS_FR], (r, t, c, s, ts), 0) : 0
                                 )
-                            ) for v in get(RTP_VNT, (r, t, p), Set());
+                            ) for v in get(sets.RTP_VNT, (r, t, p), Set());
                             init = 0,
-                        ) for ts in RPC_TS[r, p, c]
-                    ) for p in get(RCIE_P, (r, c, "IMP"), Set()) if (r, t, p) in RTP_VARA;
+                        ) for ts in sets.RPC_TS[r, p, c]
+                    ) for p in get(sets.RCIE_P, (r, c, "IMP"), Set()) if (r, t, p) in data[:RTP_VARA];
                     init = 0,
                 )
-            ) * COM_IE[r, t, c, s]
+            ) * data[:COM_IE][r, t, c, s]
         ) >=
         sum(
             (
-                (r, p, c) in RPC_STG ?
+                (r, p, c) in data[:RPC_STG] ?
                 sum(
                     sum(
                         StgFlo[(r, v, t, p, c, ts, "IN")] *
-                        get(RS_FR, (r, s, ts), 0) *
-                        (1 + (!isnothing(RTCS_FR) ? get(RTCS_FR, (r, t, c, s, ts), 0) : 0))
-                        for v in get(RTP_VNT, (r, t, p), Set());
+                        get(data[:RS_FR], (r, s, ts), 0) *
+                        (1 + (!isnothing(data[:RTCS_FR]) ? get(data[:RTCS_FR], (r, t, c, s, ts), 0) : 0))
+                        for v in get(sets.RTP_VNT, (r, t, p), Set());
                         init = 0,
-                    ) for ts in RPC_TS[r, p, c]
+                    ) for ts in sets.RPC_TS[r, p, c]
                 ) :
                 (sum(
                     sum(
                         PrcFlo[(r, v, t, p, c, ts)] *
-                        get(RS_FR, (r, s, ts), 0) *
-                        (1 + (!isnothing(RTCS_FR) ? get(RTCS_FR, (r, t, c, s, ts), 0) : 0))
-                        for v in get(RTP_VNT, (r, t, p), Set());
+                        get(data[:RS_FR], (r, s, ts), 0) *
+                        (1 + (!isnothing(data[:RTCS_FR]) ? get(data[:RTCS_FR], (r, t, c, s, ts), 0) : 0))
+                        for v in get(sets.RTP_VNT, (r, t, p), Set());
                         init = 0,
-                    ) for ts in RPC_TS[r, p, c]
+                    ) for ts in sets.RPC_TS[r, p, c]
                 ))
-            ) for p in get(RCIO_P, (r, c, "IN"), Set()) if (r, t, p) in RTP_VARA;
+            ) for p in get(sets.RCIO_P, (r, c, "IN"), Set()) if (r, t, p) in data[:RTP_VARA];
             init = 0,
         ) +
         sum(
             sum(
                 sum(
                     IreFlo[(r, v, t, p, c, ts, "EXP")] *
-                    get(RS_FR, (r, s, ts), 0) *
-                    (1 + (!isnothing(RTCS_FR) ? get(RTCS_FR, (r, t, c, s, ts), 0) : 0)) for
-                    v in get(RTP_VNT, (r, t, p), Set());
+                    get(data[:RS_FR], (r, s, ts), 0) *
+                    (1 + (!isnothing(data[:RTCS_FR]) ? get(data[:RTCS_FR], (r, t, c, s, ts), 0) : 0)) for
+                    v in get(sets.RTP_VNT, (r, t, p), Set());
                     init = 0,
-                ) for ts in RPC_TS[r, p, c]
-            ) for p in get(RCIE_P, (r, c, "EXP"), Set()) if (r, t, p) in RTP_VARA;
+                ) for ts in sets.RPC_TS[r, p, c]
+            ) for p in get(sets.RCIE_P, (r, c, "EXP"), Set()) if (r, t, p) in data[:RTP_VARA];
             init = 0,
         ) +
-        get(COM_PROJ, (r, t, c), 0) * COM_FR[r, t, c, s]
+        get(data[:COM_PROJ], (r, t, c), 0) * data[:COM_FR][r, t, c, s]
     )
 
     # %% Commodity Balance - Equal
-    @constraint(
+    JuMP.@constraint(
         model,
         EQE_COMBAL[(r, t, c, s) in indices["EQE_COMBAL"]],
         (
-            !isnothing(RHS_COMPRD) && ((r, t, c, s) in RHS_COMPRD) ? ComPrd[(r, t, c, s)] :
+            !isnothing(data[:RHS_COMPRD]) && ((r, t, c, s) in data[:RHS_COMPRD]) ? ComPrd[(r, t, c, s)] :
             (
                 sum(
                     (
-                        (r, p, c) in RPC_STG ?
+                        (r, p, c) in data[:RPC_STG] ?
                         sum(
                             sum(
                                 StgFlo[(r, v, t, p, c, ts, "OUT")] *
-                                get(RS_FR, (r, s, ts), 0) *
+                                get(data[:RS_FR], (r, s, ts), 0) *
                                 (
                                     1 + (
-                                        !isnothing(RTCS_FR) ?
-                                        get(RTCS_FR, (r, t, c, s, ts), 0) : 0
+                                        !isnothing(data[:RTCS_FR]) ?
+                                        get(data[:RTCS_FR], (r, t, c, s, ts), 0) : 0
                                     )
                                 ) *
-                                STG_EFF[r, v, p] for v in get(RTP_VNT, (r, t, p), Set());
+                                data[:STG_EFF][r, v, p] for v in get(sets.RTP_VNT, (r, t, p), Set());
                                 init = 0,
-                            ) for ts in RPC_TS[r, p, c]
+                            ) for ts in sets.RPC_TS[r, p, c]
                         ) :
                         (sum(
                             sum(
                                 PrcFlo[(r, v, t, p, c, ts)] *
-                                get(RS_FR, (r, s, ts), 0) *
+                                get(data[:RS_FR], (r, s, ts), 0) *
                                 (
                                     1 + (
-                                        !isnothing(RTCS_FR) ?
-                                        get(RTCS_FR, (r, t, c, s, ts), 0) : 0
+                                        !isnothing(data[:RTCS_FR]) ?
+                                        get(data[:RTCS_FR], (r, t, c, s, ts), 0) : 0
                                     )
-                                ) for v in get(RTP_VNT, (r, t, p), Set());
+                                ) for v in get(sets.RTP_VNT, (r, t, p), Set());
                                 init = 0,
-                            ) for ts in RPC_TS[r, p, c]
+                            ) for ts in sets.RPC_TS[r, p, c]
                         ))
-                    ) for p in get(RCIO_P, (r, c, "OUT"), Set()) if (r, t, p) in RTP_VARA;
+                    ) for p in get(sets.RCIO_P, (r, c, "OUT"), Set()) if (r, t, p) in data[:RTP_VARA];
                     init = 0,
                 ) + sum(
                     sum(
                         sum(
                             IreFlo[(r, v, t, p, c, ts, "IMP")] *
-                            get(RS_FR, (r, s, ts), 0) *
+                            get(data[:RS_FR], (r, s, ts), 0) *
                             (
                                 1 + (
-                                    !isnothing(RTCS_FR) ?
-                                    get(RTCS_FR, (r, t, c, s, ts), 0) : 0
+                                    !isnothing(data[:RTCS_FR]) ?
+                                    get(data[:RTCS_FR], (r, t, c, s, ts), 0) : 0
                                 )
-                            ) for v in get(RTP_VNT, (r, t, p), Set());
+                            ) for v in get(sets.RTP_VNT, (r, t, p), Set());
                             init = 0,
-                        ) for ts in RPC_TS[r, p, c]
-                    ) for p in get(RCIE_P, (r, c, "IMP"), Set()) if (r, t, p) in RTP_VARA;
+                        ) for ts in sets.RPC_TS[r, p, c]
+                    ) for p in get(sets.RCIE_P, (r, c, "IMP"), Set()) if (r, t, p) in data[:RTP_VARA];
                     init = 0,
                 )
-            ) * COM_IE[r, t, c, s]
+            ) * data[:COM_IE][r, t, c, s]
         ) ==
         sum(
             (
-                (r, p, c) in RPC_STG ?
+                (r, p, c) in data[:RPC_STG] ?
                 sum(
                     sum(
                         StgFlo[(r, v, t, p, c, ts, "IN")] *
-                        get(RS_FR, (r, s, ts), 0) *
-                        (1 + (!isnothing(RTCS_FR) ? get(RTCS_FR, (r, t, c, s, ts), 0) : 0))
-                        for v in get(RTP_VNT, (r, t, p), Set());
+                        get(data[:RS_FR], (r, s, ts), 0) *
+                        (1 + (!isnothing(data[:RTCS_FR]) ? get(data[:RTCS_FR], (r, t, c, s, ts), 0) : 0))
+                        for v in get(sets.RTP_VNT, (r, t, p), Set());
                         init = 0,
-                    ) for ts in RPC_TS[r, p, c]
+                    ) for ts in sets.RPC_TS[r, p, c]
                 ) :
                 (sum(
                     sum(
                         PrcFlo[(r, v, t, p, c, ts)] *
-                        get(RS_FR, (r, s, ts), 0) *
-                        (1 + (!isnothing(RTCS_FR) ? get(RTCS_FR, (r, t, c, s, ts), 0) : 0))
-                        for v in get(RTP_VNT, (r, t, p), Set());
+                        get(data[:RS_FR], (r, s, ts), 0) *
+                        (1 + (!isnothing(data[:RTCS_FR]) ? get(data[:RTCS_FR], (r, t, c, s, ts), 0) : 0))
+                        for v in get(sets.RTP_VNT, (r, t, p), Set());
                         init = 0,
-                    ) for ts in RPC_TS[r, p, c]
+                    ) for ts in sets.RPC_TS[r, p, c]
                 ))
-            ) for p in get(RCIO_P, (r, c, "IN"), Set()) if (r, t, p) in RTP_VARA;
+            ) for p in get(sets.RCIO_P, (r, c, "IN"), Set()) if (r, t, p) in data[:RTP_VARA];
             init = 0,
         ) +
         sum(
             sum(
                 sum(
                     IreFlo[(r, v, t, p, c, ts, "EXP")] *
-                    get(RS_FR, (r, s, ts), 0) *
-                    (1 + (!isnothing(RTCS_FR) ? get(RTCS_FR, (r, t, c, s, ts), 0) : 0)) for
-                    v in get(RTP_VNT, (r, t, p), Set());
+                    get(data[:RS_FR], (r, s, ts), 0) *
+                    (1 + (!isnothing(data[:RTCS_FR]) ? get(data[:RTCS_FR], (r, t, c, s, ts), 0) : 0)) for
+                    v in get(sets.RTP_VNT, (r, t, p), Set());
                     init = 0,
-                ) for ts in RPC_TS[r, p, c]
-            ) for p in get(RCIE_P, (r, c, "EXP"), Set()) if (r, t, p) in RTP_VARA;
+                ) for ts in sets.RPC_TS[r, p, c]
+            ) for p in get(sets.RCIE_P, (r, c, "EXP"), Set()) if (r, t, p) in data[:RTP_VARA];
             init = 0,
         ) +
-        ((r, t, c, s) in RHS_COMBAL ? 1 : 0) * ComNet[(r, t, c, s)] +
-        get(COM_PROJ, (r, t, c), 0) * COM_FR[r, t, c, s]
+        ((r, t, c, s) in data[:RHS_COMBAL] ? 1 : 0) * ComNet[(r, t, c, s)] +
+        get(data[:COM_PROJ], (r, t, c), 0) * data[:COM_FR][r, t, c, s]
     )
 
     # %% Commodity Production
-    @constraint(
+    JuMP.@constraint(
         model,
         EQE_COMPRD[(r, t, c, s) in indices["EQE_COMPRD"]],
         sum(
             (
-                (r, p, c) in RPC_STG ?
+                (r, p, c) in data[:RPC_STG] ?
                 sum(
                     sum(
                         StgFlo[(r, v, t, p, c, ts, "OUT")] *
-                        get(RS_FR, (r, s, ts), 0) *
+                        get(data[:RS_FR], (r, s, ts), 0) *
                         (
                             1 +
-                            (!isnothing(RTCS_FR) ? get(RTCS_FR, (r, t, c, s, ts), 0) : 0)
+                            (!isnothing(data[:RTCS_FR]) ? get(data[:RTCS_FR], (r, t, c, s, ts), 0) : 0)
                         ) *
-                        STG_EFF[r, v, p] for v in RTP_VNT[r, t, p]
-                    ) for ts in RPC_TS[r, p, c]
+                        data[:STG_EFF][r, v, p] for v in sets.RTP_VNT[r, t, p]
+                    ) for ts in sets.RPC_TS[r, p, c]
                 ) :
                 sum(
                     sum(
                         PrcFlo[(r, v, t, p, c, ts)] *
-                        get(RS_FR, (r, s, ts), 0) *
-                        (1 + (!isnothing(RTCS_FR) ? get(RTCS_FR, (r, t, c, s, ts), 0) : 0))
-                        for v in RTP_VNT[r, t, p]
-                    ) for ts in RPC_TS[r, p, c]
+                        get(data[:RS_FR], (r, s, ts), 0) *
+                        (1 + (!isnothing(data[:RTCS_FR]) ? get(data[:RTCS_FR], (r, t, c, s, ts), 0) : 0))
+                        for v in sets.RTP_VNT[r, t, p]
+                    ) for ts in sets.RPC_TS[r, p, c]
                 )
             ) + sum(
                 sum(
                     sum(
                         IreFlo[(r, v, t, p, c, ts, "IMP")] *
-                        get(RS_FR, (r, s, ts), 0) *
-                        (1 + (!isnothing(RTCS_FR) ? get(RTCS_FR, (r, t, c, s, ts), 0) : 0))
-                        for v in RTP_VNT[r, t, p]
-                    ) for ts in RPC_TS[r, p, c]
-                ) for p in RCIE_P[r, c, "IMP"] if (r, t, p) in RTP_VARA
-            ) for p in RCIO_P[r, c, "OUT"] if (r, t, p) in RTP_VARA
-        ) * COM_IE[r, t, c, s] == ComPrd[(r, t, c, s)]
+                        get(data[:RS_FR], (r, s, ts), 0) *
+                        (1 + (!isnothing(data[:RTCS_FR]) ? get(data[:RTCS_FR], (r, t, c, s, ts), 0) : 0))
+                        for v in sets.RTP_VNT[r, t, p]
+                    ) for ts in sets.RPC_TS[r, p, c]
+                ) for p in sets.RCIE_P[r, c, "IMP"] if (r, t, p) in data[:RTP_VARA]
+            ) for p in sets.RCIO_P[r, c, "OUT"] if (r, t, p) in data[:RTP_VARA]
+        ) * data[:COM_IE][r, t, c, s] == ComPrd[(r, t, c, s)]
     )
 
     # %% Timeslice Storage Transformation
-    @constraint(
+    JuMP.@constraint(
         model,
         EQ_STGTSS[(r, v, y, p, s) in indices["EQ_STGTSS"]],
         PrcAct[(r, v, y, p, s)] == sum(
             (
                 PrcAct[(r, v, y, p, all_s)] +
-                get(STG_CHRG, (r, y, p, all_s), 0) +
+                get(data[:STG_CHRG], (r, y, p, all_s), 0) +
                 sum(
-                    StgFlo[(r, v, y, p, c, all_s, io)] / PRC_ACTFLO[r, v, p, c] *
+                    StgFlo[(r, v, y, p, c, all_s, io)] / data[:PRC_ACTFLO][r, v, p, c] *
                     (io == "IN" ? 1 : -1) for
-                    (c, io) in RP_CIO[r, p] if (r, p, c) in PRC_STGTSS
+                    (c, io) in sets.RP_CIO[r, p] if (r, p, c) in data[:PRC_STGTSS]
                 ) +
                 (PrcAct[(r, v, y, p, s)] + PrcAct[(r, v, y, p, all_s)]) / 2 * (
                     (
@@ -539,19 +553,19 @@ function create_constraints(model, indices)
                             min(
                                 0,
                                 (
-                                    !isnothing(STG_LOSS) ?
-                                    get(STG_LOSS, (r, v, p, all_s), 0) : 0
+                                    !isnothing(data[:STG_LOSS]) ?
+                                    get(data[:STG_LOSS], (r, v, p, all_s), 0) : 0
                                 ),
-                            ) * G_YRFR[r, all_s] / RS_STGPRD[r, s],
+                            ) * data[:G_YRFR][r, all_s] / data[:RS_STGPRD][r, s],
                         )
                     ) +
                     max(
                         0,
-                        (!isnothing(STG_LOSS) ? get(STG_LOSS, (r, v, p, all_s), 0) : 0),
-                    ) * G_YRFR[r, all_s] / RS_STGPRD[r, s]
+                        (!isnothing(data[:STG_LOSS]) ? get(data[:STG_LOSS], (r, v, p, all_s), 0) : 0),
+                    ) * data[:G_YRFR][r, all_s] / data[:RS_STGPRD][r, s]
                 )
-            ) for all_s in TSLICE if (r, s, all_s) in RS_PRETS
+            ) for all_s in data[:TSLICE] if (r, s, all_s) in data[:RS_PRETS]
         )
     )
-
+    return
 end

--- a/src/load_data.jl
+++ b/src/load_data.jl
@@ -84,7 +84,7 @@ const data_info = Dict(
     "COEF_OBFIX" => "SELECT R,YEAR,P,CUR,value FROM COEF_OBFIX",
 )
 
-function parse_year(df::DataFrame)::DataFrame
+function parse_year(df::DataFrames.DataFrame)::DataFrames.DataFrame
     year_cols = ["ALLYEAR", "ALLYEAR2", "T", "YEAR"]
     y_cols = intersect(names(df), year_cols)
     for y_col in y_cols
@@ -93,121 +93,32 @@ function parse_year(df::DataFrame)::DataFrame
     return df
 end
 
-function read_data(file_path::String)::Dict{String,DataFrame}
+function read_data(file_path::String)::Dict{String,DataFrames.DataFrame}
     db = SQLite.DB(file_path)
-    con = DBInterface
-    data = Dict()
-    for (k, query) in data_info
-        df = DataFrame(con.execute(db, query))
-        data[k] = parse_year(df)
-    end
-    return data
+    return Dict{String,DataFrames.DataFrame}(
+        k => parse_year(
+            DataFrames.DataFrame(SQLite.DBInterface.execute(db, query))
+        ) for (k, query) in data_info
+    )
 end
 
-function create_symbol(df::DataFrame)
-    row_number = nrow(df)
-    col_number = ncol(df)
-
+function create_symbol(df::DataFrames.DataFrame)
+    row_number, col_number = size(df)
     if row_number > 0 && col_number == 1
         # One-dimensional set
-        value = Set(values(df[!, 1]))
+        return values(df[!, 1])
     elseif row_number > 0 && col_number > 1
         # Multi-dimensional set or parameter
         if "value" in names(df)
-            value = Dict(Tuple.(eachrow(df[:, Not(:value)])) .=> df.value)
+            return Dict(Tuple.(eachrow(df[:, DataFrames.Not(:value)])) .=> df.value)
         else
-            value = Set(Tuple.(eachrow(df)))
+            return Tuple.(eachrow(df))
         end
-
-    else
-        # Empty set or parameter
-        value = nothing
     end
-    return value
+    # Empty set or parameter
+    return nothing
 end
 
-function create_read_symbols(data::Dict{String,DataFrame})
-
-    # Create all the symbols from the data
-    global MILEYR = create_symbol(data["MILEYR"])
-    global MODLYR = create_symbol(data["MODLYR"])
-    global TSLICE = create_symbol(data["TSLICE"])
-    global REGION = create_symbol(data["REGION"])
-    global PROCESS = create_symbol(data["PROCESS"])
-    global COMGRP = create_symbol(data["COMGRP"])
-    global COMMTY = create_symbol(data["COMMTY"])
-    global CURRENCY = create_symbol(data["CURRENCY"])
-    global RDCUR = create_symbol(data["RDCUR"])
-    global RC = create_symbol(data["RC"])
-    global RP = create_symbol(data["RP"])
-    global RP_FLO = create_symbol(data["RP_FLO"])
-    global RP_STD = create_symbol(data["RP_STD"])
-    global RP_IRE = create_symbol(data["RP_IRE"])
-    global RP_STG = create_symbol(data["RP_STG"])
-    global RP_PGACT = create_symbol(data["RP_PGACT"])
-    global RP_PGFLO = create_symbol(data["RP_PGFLO"])
-    global PRC_ACT = create_symbol(data["PRC_ACT"])
-    global PRC_VINT = create_symbol(data["PRC_VINT"])
-    global RP_AIRE = create_symbol(data["RP_AIRE"])
-    global DEM = create_symbol(data["DEM"])
-    global COM_GMAP = create_symbol(data["COM_GMAP"])
-    global TOP = create_symbol(data["TOP"])
-    global PRC_TS = create_symbol(data["PRC_TS"])
-    global RPS_S1 = create_symbol(data["RPS_S1"])
-    global RPS_STG = create_symbol(data["RPS_STG"])
-    global TS_MAP = create_symbol(data["TS_MAP"])
-    global RS_PRETS = create_symbol(data["RS_PRETS"])
-    global RPC = create_symbol(data["RPC"])
-    global RPC_PG = create_symbol(data["RPC_PG"])
-    global RPC_IRE = create_symbol(data["RPC_IRE"])
-    global RPC_STG = create_symbol(data["RPC_STG"])
-    global PRC_STGTSS = create_symbol(data["PRC_STGTSS"])
-    global RPG_ACE = create_symbol(data["RPG_ACE"])
-    global RPC_ACE = create_symbol(data["RPC_ACE"])
-    global AFS = create_symbol(data["AFS"])
-    global RTP = create_symbol(data["RTP"])
-    global RTP_VARA = create_symbol(data["RTP_VARA"])
-    global RTP_IPRI = create_symbol(data["RTP_IPRI"])
-    global RTP_VARP = create_symbol(data["RTP_VARP"])
-    global RPCS_VAR = create_symbol(data["RPCS_VAR"])
-    global RPCC_FFUNC = create_symbol(data["RPCC_FFUNC"])
-    global RTP_VINTYR = create_symbol(data["RTP_VINTYR"])
-    global RTCS = create_symbol(data["RTCS"])
-    global RCS_COMBAL = create_symbol(data["RCS_COMBAL"])
-    global RCS_COMPRD = create_symbol(data["RCS_COMPRD"])
-    global RHS_COMBAL = create_symbol(data["RHS_COMBAL"])
-    global RHS_COMPRD = create_symbol(data["RHS_COMPRD"])
-    global RP_PTRAN = create_symbol(data["RP_PTRAN"])
-    global RTP_CPTYR = create_symbol(data["RTP_CPTYR"])
-    global IS_LINT = create_symbol(data["IS_LINT"])
-    global IS_ACOST = create_symbol(data["IS_ACOST"])
-    global G_YRFR = create_symbol(data["G_YRFR"])
-    global RS_STGPRD = create_symbol(data["RS_STGPRD"])
-    global RS_FR = create_symbol(data["RS_FR"])
-    global PRC_CAPACT = create_symbol(data["PRC_CAPACT"])
-    global PRC_SC = create_symbol(data["PRC_SC"])
-    global RS_STGAV = create_symbol(data["RS_STGAV"])
-    global RTCS_FR = create_symbol(data["RTCS_FR"])
-    global COM_PROJ = create_symbol(data["COM_PROJ"])
-    global COM_IE = create_symbol(data["COM_IE"])
-    global COM_FR = create_symbol(data["COM_FR"])
-    global NCAP_PASTI = create_symbol(data["NCAP_PASTI"])
-    global CAP_BND = create_symbol(data["CAP_BND"])
-    global NCAP_BND = create_symbol(data["NCAP_BND"])
-    global COEF_CPT = create_symbol(data["COEF_CPT"])
-    global COEF_AF = create_symbol(data["COEF_AF"])
-    global COEF_PTRAN = create_symbol(data["COEF_PTRAN"])
-    global FLO_SHAR = create_symbol(data["FLO_SHAR"])
-    global PRC_ACTFLO = create_symbol(data["PRC_ACTFLO"])
-    global STG_EFF = create_symbol(data["STG_EFF"])
-    global STG_LOSS = create_symbol(data["STG_LOSS"])
-    global STG_CHRG = create_symbol(data["STG_CHRG"])
-    global ACT_EFF = create_symbol(data["ACT_EFF"])
-    global OBJ_PVT = create_symbol(data["OBJ_PVT"])
-    global OBJ_LINT = create_symbol(data["OBJ_LINT"])
-    global OBJ_ACOST = create_symbol(data["OBJ_ACOST"])
-    global OBJ_IPRIC = create_symbol(data["OBJ_IPRIC"])
-    global COEF_OBINV = create_symbol(data["COEF_OBINV"])
-    global COEF_OBFIX = create_symbol(data["COEF_OBFIX"])
-
+function create_read_symbols(data::Dict{String,DataFrames.DataFrame})
+    return Dict(Symbol(k) => create_symbol(v) for (k, v) in data)
 end

--- a/src/objective.jl
+++ b/src/objective.jl
@@ -1,6 +1,11 @@
 # Requires JuMP
 
-function create_objective(model)
-    @expression(model, obj, sum(RegObj[o, r, cur] for o in OBV for (r, cur) in RDCUR))
-    @objective(model, Min, obj)
+function create_objective!(model, data)
+    RegObj = model[:RegObj]
+    JuMP.@objective(
+        model,
+        Min,
+        sum(RegObj[o,r,cur] for o in OBV for (r, cur) in data[:RDCUR]),
+    )
+    return
 end

--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -1,6 +1,11 @@
 # Requires JuMP
 
 # Define additional parameters
-function create_parameters()
-    global Containers.@container(MILE[y in MODLYR], y in MILEYR ? 1 : 0)
+function create_parameters!(model, data)
+    JuMP.JuMP.@expression(
+        model,
+        MILE[y in data[:MODLYR]],
+        y in data[:MILEYR] ? 1 : 0,
+    )
+    return
 end

--- a/src/sets.jl
+++ b/src/sets.jl
@@ -1,20 +1,24 @@
 # System Sets
+
 const YEAR = union(0, (1900:2200))
-const INOUT = Set(["IN", "OUT"])
-const IMPEXP = Set(["IMP", "EXP"])
-const LIM = Set(["LO", "UP", "FX", "N"])
 
-const TSLVL = Set(["ANNUAL", "SEASON", "WEEKLY", "DAYNITE"])
+const INOUT = ["IN", "OUT"]
 
-const COM_TYPE = Set([
+const IMPEXP = ["IMP", "EXP"]
+
+const LIM = ["LO", "UP", "FX", "N"]
+
+const TSLVL = ["ANNUAL", "SEASON", "WEEKLY", "DAYNITE"]
+
+const COM_TYPE = [
     "DEM",         # Demands
     "NRG",         # Energy
     "MAT",         # Material
     "ENV",         # Environmental
     "FIN",          # Financial
-])
+]
 
-const PRC_GRP = Set([
+const PRC_GRP = [
     "XTRACT",  # Extraction
     "RENEW",   # Renewables (limited)
     "PRE",     # Energy
@@ -32,12 +36,12 @@ const PRC_GRP = Set([
     "IRE",     # Inter-region exchange (IMPort/EXPort)
     "STK",     # Stockpiling
     "MISC",    # Miscellaneous
-    "STS",      # Time-slice storage (excluding night storages)
-])
+    "STS",     # Time-slice storage (excluding night storages)
+]
 
-const UPT = Set(["COLD", "WARM", "HOT"])
+const UPT = ["COLD", "WARM", "HOT"]
 
-const UC_NAME = Set([
+const UC_NAME = [
     "COST",
     "DELIV",
     "TAX",
@@ -68,14 +72,14 @@ const UC_NAME = Set([
     "NCAP_COST",
     "NCAP_ITAX",
     "NCAP_ISUB",
-])
+]
 
 const UC_GRPTYPE =
-    Set(["ACT", "FLO", "IRE", "CAP", "NCAP", "COMNET", "COMPRD", "COMCON", "UCN"])
+    ["ACT", "FLO", "IRE", "CAP", "NCAP", "COMNET", "COMPRD", "COMCON", "UCN"]
 
-const UC_COST = Set(["COST", "DELIV", "TAX", "SUB", "ANNUL"])
+const UC_COST = ["COST", "DELIV", "TAX", "SUB", "ANNUL"]
 
-const COSTAGG = Set([
+const COSTAGG = [
     "INV",
     "INVTAX",
     "INVSUB",
@@ -100,7 +104,7 @@ const COSTAGG = Set([
     "ALLTAX",
     "ALLSUB",
     "ALLTAXSUB",
-])
+]
 
-# Internal Sets	
-const OBV = Set(["OBJINV", "OBJFIX", "OBJVAR"])
+# Internal Sets
+const OBV = ["OBJINV", "OBJFIX", "OBJVAR"]

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -1,14 +1,14 @@
 # Requires JuMP
 
-function create_variables!(model, indices, read_symbols)
-    lb(k, i) = get(read_symbols[k], tuple(i..., "LB"), 0.0)
-    ub(k, i) = get(read_symbols[k], tuple(i..., "UB"), Inf)
-    JuMP.JuMP.@variables(model, begin
-        RegObj[OBV, read_symbols[:REGION], read_symbols[:CURRENCY]] >= 0
+function create_variables!(model, indices, data)
+    lo(k, i) = get(data[k], tuple(i..., "LO"), 0.0)
+    up(k, i) = get(data[k], tuple(i..., "UP"), Inf)
+    JuMP.@variables(model, begin
+        RegObj[OBV, data[:REGION], data[:CURRENCY]] >= 0
         ComPrd[indices["var_ComPrd"]] >= 0
         ComNet[indices["var_ComNet"]] >= 0
-        lb(:CAP_BND, i) <= PrcCap[i in indices["var_PrcCap"]] <= ub(:CAP_BND, i)
-        lb(:NCAP_BND, i) <= PrcNcap[i in indices["var_PrcCap"]] <= ub(:NCAP_BND, i)
+        lo(:CAP_BND, i) <= PrcCap[i in indices["var_PrcCap"]] <= up(:CAP_BND, i)
+        lo(:NCAP_BND, i) <= PrcNcap[i in indices["var_PrcCap"]] <= up(:NCAP_BND, i)
         PrcAct[indices["var_PrcAct"]] >= 0
         PrcFlo[indices["var_PrcFlo"]] >= 0
         IreFlo[indices["var_IreFlo"]] >= 0

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -1,51 +1,18 @@
 # Requires JuMP
 
-function PrcCap_bounds(r, y, p, bd)
-    if haskey(CAP_BND, (r, y, p, bd))
-        return CAP_BND[r, y, p, bd]
-    end
-    if bd == "LO"
-        return 0
-    end
-    if bd == "UP"
-        return Inf
-    end
-end
-
-function PrcNcap_bounds(r, y, p, bd)
-    if haskey(NCAP_BND, (r, y, p, bd))
-        return NCAP_BND[r, y, p, bd]
-    end
-    if bd == "LO"
-        return 0
-    end
-    if bd == "UP"
-        return Inf
-    end
-end
-
-function create_variables(model, indices)
-    # %% Variables
-    global RegObj = @variable(model, RegObj[OBV, REGION, CURRENCY] >= 0)
-    global ComPrd = @variable(model, ComPrd[(r, t, c, s) in indices["var_ComPrd"]] >= 0)
-    global ComNet = @variable(model, ComNet[(r, t, c, s) in indices["var_ComNet"]] >= 0)
-    global PrcCap = @variable(
-        model,
-        PrcCap_bounds(r, v, p, "LO") <=
-        PrcCap[(r, v, p) in indices["var_PrcCap"]] <=
-        PrcCap_bounds(r, v, p, "UP")
-    )
-    global PrcNcap = @variable(
-        model,
-        PrcNcap_bounds(r, v, p, "LO") <=
-        PrcNcap[(r, v, p) in indices["var_PrcCap"]] <=
-        PrcNcap_bounds(r, v, p, "UP")
-    )
-    global PrcAct = @variable(model, PrcAct[(r, v, t, p, s) in indices["var_PrcAct"]] >= 0)
-    global PrcFlo =
-        @variable(model, PrcFlo[(r, v, t, p, c, s) in indices["var_PrcFlo"]] >= 0)
-    global IreFlo =
-        @variable(model, IreFlo[(r, v, t, p, c, s, ie) in indices["var_IreFlo"]] >= 0)
-    global StgFlo =
-        @variable(model, StgFlo[(r, v, t, p, c, s, io) in indices["var_StgFlo"]] >= 0)
+function create_variables!(model, indices, read_symbols)
+    lb(k, i) = get(read_symbols[k], tuple(i..., "LB"), 0.0)
+    ub(k, i) = get(read_symbols[k], tuple(i..., "UB"), Inf)
+    JuMP.JuMP.@variables(model, begin
+        RegObj[OBV, read_symbols[:REGION], read_symbols[:CURRENCY]] >= 0
+        ComPrd[indices["var_ComPrd"]] >= 0
+        ComNet[indices["var_ComNet"]] >= 0
+        lb(:CAP_BND, i) <= PrcCap[i in indices["var_PrcCap"]] <= ub(:CAP_BND, i)
+        lb(:NCAP_BND, i) <= PrcNcap[i in indices["var_PrcCap"]] <= ub(:NCAP_BND, i)
+        PrcAct[indices["var_PrcAct"]] >= 0
+        PrcFlo[indices["var_PrcFlo"]] >= 0
+        IreFlo[indices["var_IreFlo"]] >= 0
+        StgFlo[indices["var_StgFlo"]] >= 0
+    end)
+    return
 end


### PR DESCRIPTION
I attempted to make a fairly minimal set of changes. <s>, but there's a difference between the two models I need to debug.</s>

## Before

```
% julia --project=. demo.jl 
Create demo: 21.260735 seconds (28.36 M allocations: 1.897 GiB, 3.32% gc time, 99.10% compilation time: <1% of which was recompilation)
Running HiGHS 1.10.0 (git hash: fd8665394e): Copyright (c) 2025 HiGHS under MIT licence terms
LP   has 604 rows; 950 cols; 1920 nonzeros
Coefficient ranges:
  Matrix [1e-02, 1e+04]
  Cost   [1e+00, 1e+00]
  Bound  [1e-01, 1e+01]
  RHS    [9e-02, 8e+03]
Presolving model
265 rows, 287 cols, 965 nonzeros  0s
Dependent equations search running on 25 equations with time limit of 1000.00s
Dependent equations search removed 0 rows and 0 nonzeros in 0.00s (limit = 1000.00s)
228 rows, 245 cols, 826 nonzeros  0s
Presolve : Reductions: rows 228(-376); columns 245(-705); elements 826(-1094)
Solving the presolved LP
Using EKK dual simplex solver - serial
  Iteration        Objective     Infeasibilities num(sum)
          0     1.2861637975e+04 Pr: 30(74.9799) 0s
        157     3.8706151237e+04 Pr: 0(0); Du: 0(4.9738e-14) 0s
Solving the original LP from the solution after postsolve
Model status        : Optimal
Simplex   iterations: 157
Objective value     :  3.8706151237e+04
Relative P-D gap    :  3.7595872395e-16
HiGHS run time      :          0.01
Solve model: 0.124531 seconds (57.21 k allocations: 4.288 MiB, 89.49% compilation time: 51% of which was recompilation)
```

## This PR

```
(base) oscar@MacBookPro TIMES % julia --project=. demo.jl
Create demo: 1.204018 seconds (762.20 k allocations: 47.372 MiB, 1.88% gc time, 92.00% compilation time: 44% of which was recompilation)
Running HiGHS 1.10.0 (git hash: fd8665394e): Copyright (c) 2025 HiGHS under MIT licence terms
LP   has 604 rows; 950 cols; 1920 nonzeros
Coefficient ranges:
  Matrix [1e-02, 1e+04]
  Cost   [1e+00, 1e+00]
  Bound  [1e-01, 1e+01]
  RHS    [9e-02, 8e+03]
Presolving model
265 rows, 287 cols, 965 nonzeros  0s
Dependent equations search running on 25 equations with time limit of 1000.00s
Dependent equations search removed 0 rows and 0 nonzeros in 0.00s (limit = 1000.00s)
228 rows, 245 cols, 826 nonzeros  0s
Presolve : Reductions: rows 228(-376); columns 245(-705); elements 826(-1094)
Solving the presolved LP
Using EKK dual simplex solver - serial
  Iteration        Objective     Infeasibilities num(sum)
          0     1.2861637975e+04 Pr: 30(74.9799) 0s
        157     3.8706151237e+04 Pr: 0(0); Du: 0(4.9738e-14) 0s
Solving the original LP from the solution after postsolve
Model status        : Optimal
Simplex   iterations: 157
Objective value     :  3.8706151237e+04
Relative P-D gap    :  3.7595872395e-16
HiGHS run time      :          0.00
Solve model: 0.108321 seconds (57.21 k allocations: 4.288 MiB, 92.00% compilation time: 55% of which was recompilation)
```